### PR TITLE
"world.schem" file should not be required

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,12 +184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "downcast-rs"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
-
-[[package]]
 name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,13 +230,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "falcon_event"
-version = "0.2.0"
-dependencies = [
- "downcast-rs",
 ]
 
 [[package]]

--- a/config/falcon.toml
+++ b/config/falcon.toml
@@ -18,6 +18,7 @@ pitch = 0.0
 [server]
 max_players = -1
 description = '§eFalcon server§r§b!!!'
+#! Comment out, or remove 'world' so Falcon will start with no schematic.
 world = "world.schem"
 
 [versions]

--- a/config/falcon.toml
+++ b/config/falcon.toml
@@ -16,10 +16,13 @@ yaw = 0.0
 pitch = 0.0
 
 [server]
+# -1 means unlimited players.
 max_players = -1
 description = '§eFalcon server§r§b!!!'
-#! Comment out, or remove 'world' so Falcon will start with no schematic.
+# Omitting this setting will start the server with an empty world.
 world = "world.schem"
 
 [versions]
+# List of protocol versions that are compatible but should not be allowed to connect.
 excluded = []
+

--- a/config/falcon.toml
+++ b/config/falcon.toml
@@ -18,6 +18,7 @@ pitch = 0.0
 [server]
 max_players = -1
 description = '§eFalcon server§r§b!!!'
+world = "world.schem"
 
 [versions]
 excluded = []

--- a/crates/core/src/server/config.rs
+++ b/crates/core/src/server/config.rs
@@ -51,6 +51,10 @@ impl FalconConfig {
         &self.server.description
     }
 
+    pub fn world_file(&self) -> Option<&str> {
+        self.server.world.as_deref()
+    }
+
     pub fn allow_flight(&self) -> bool {
         self.players.allow_flight
     }
@@ -110,6 +114,8 @@ impl Default for PlayerSettings {
 pub struct ServerSettings {
     max_players: i32,
     description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    world: Option<String>,
 }
 
 impl Default for ServerSettings {
@@ -117,6 +123,7 @@ impl Default for ServerSettings {
         ServerSettings {
             max_players: -1,
             description: String::from("§eFalcon server§r§b!!!"),
+            world: None,
         }
     }
 }

--- a/crates/main/src/main.rs
+++ b/crates/main/src/main.rs
@@ -39,7 +39,9 @@ async fn main() {
 
     debug!("Loading config!");
     if let Err(ref e) = FalconConfig::init_config("config/falcon.toml")
-        .with_context(|| "The configuration file could not be loaded!")
+        .with_context(|| "The configuration file could not be loaded! \
+                      This can most likely be solved by removing the config file and adjusting \
+                      the config again after having launched (and shut down) FalconMC.")
     {
         print_error!(e);
         return;

--- a/crates/main/src/server/mod.rs
+++ b/crates/main/src/server/mod.rs
@@ -2,6 +2,7 @@ use std::io::Read;
 use std::thread;
 
 use anyhow::{Context, Result};
+use falcon_core::server::config::FalconConfig;
 use falcon_logic::server::ServerWrapper;
 use flate2::read::GzDecoder;
 use tokio::sync::mpsc::unbounded_channel;
@@ -9,6 +10,7 @@ use tokio::sync::mpsc::unbounded_channel;
 use falcon_core::schematic::{SchematicData, SchematicVersionedRaw};
 use falcon_core::ShutdownHandle;
 use falcon_logic::{FalconServer, FalconWorld};
+
 use tracing::{info, debug};
 
 use crate::network::NetworkListener;
@@ -19,24 +21,29 @@ pub mod console;
 pub(crate) fn start_server(shutdown_handle: ShutdownHandle) -> Result<()> {
     info!("Starting server thread...");
 
-    let world = {
-        let world_file = std::fs::read("./world.schem")
-            .with_context(|| "Could not load `world.schem`, stopping launch")?;
-        let mut gz = GzDecoder::new(&world_file[..]);
-        let mut decompressed_world = Vec::new();
-        gz.read_to_end(&mut decompressed_world)
-            .with_context(|| "Could not decompress world.schem, is this a valid schematic?")?;
-        debug!("Checkpoint - loaded schem file");
-        let schematic: SchematicVersionedRaw = fastnbt::from_bytes(&decompressed_world)
-            .with_context(|| "Could not parse schematic file, is this valid nbt?")?;
-        debug!("Checkpoint - deserialized into raw format");
-        let data = SchematicData::try_from(schematic).with_context(|| {
-            "Invalid schematic, this server cannot use this schematic currently!"
-        })?;
-        debug!("Checkpoint - parsed raw format");
-        FalconWorld::try_from(data)?
+    let world = match FalconConfig::global().world_file() {
+        Some(world_file) => { 
+            let world_file = std::fs::read(world_file)
+                .with_context(|| "Could not load world schematic, stopping launch")?;
+            let mut gz = GzDecoder::new(&world_file[..]);
+            let mut decompressed_world = Vec::new();
+            gz.read_to_end(&mut decompressed_world)
+                .with_context(|| "Could not decompress world.schem, is this a valid schematic?")?;
+            debug!("Checkpoint - loaded schem file");
+            let schematic: SchematicVersionedRaw = fastnbt::from_bytes(&decompressed_world)
+                .with_context(|| "Could not parse schematic file, is this valid nbt?")?;
+            debug!("Checkpoint - deserialized into raw format");
+            let data = SchematicData::try_from(schematic).with_context(|| {
+                "Invalid schematic, this server cannot use this schematic currently!"
+            })?;
+            
+            debug!("Checkpoint - parsed raw format");
+            info!("Loaded world");
+
+            FalconWorld::try_from(data)?
+        }
+        None => FalconWorld::new(0, 0, 0, 0, 0),
     };
-    info!("Loaded world");
 
     let console_rx = ConsoleListener::start_console(shutdown_handle.clone())?;
     let (server_tx, server_rx) = unbounded_channel();


### PR DESCRIPTION
Currently the server crashes when a `world.schem` file is not present in the working directory. This is essentially being overly careful since an empty world would also suffice. This closes #8 

This pull request needs to do the following things:
- [x] Add a new *optional* config entry that specifies where the world file can be located at, if no world should be loaded, this should be omitted.
- [x] In `falcon_main`, before creating the world instance, this config entry should be checked and create the `FalconWorld` according to its value.