### PR TITLE
1.8.9 now gets properly kicked

### DIFF
--- a/crates/receive/src/v1_8_9/login.rs
+++ b/crates/receive/src/v1_8_9/login.rs
@@ -18,10 +18,16 @@ impl PacketHandler<FalconConnection> for LoginStartPacket {
     fn handle_packet(self, connection: &mut FalconConnection) -> TaskScheduleResult {
         let version = connection.handler_state().protocol_id();
 
-         if FalconConfig::ALLOWED_VERSIONS.contains(&!47) == false {
+        if !FalconConfig::ALLOWED_VERSIONS.contains(&version.unsigned_abs()) {
              connection.disconnect(ChatComponent::from_text(
-                 "Incompatible or Disabled version",
+                 "Incompatible version",
                  ComponentStyle::with_version(version.unsigned_abs()).color_if_absent(ChatColor::Red)
+            ));
+        } 
+        if FalconConfig::global().excluded_versions().contains(&version.unsigned_abs()) {
+            connection.disconnect(ChatComponent::from_text(
+                "Disabled version",
+                ComponentStyle::with_version(version.unsigned_abs()).color_if_absent(ChatColor::Red)
             ));
         } else {
             let wrapper = connection.wrapper();

--- a/crates/receive/src/v1_8_9/login.rs
+++ b/crates/receive/src/v1_8_9/login.rs
@@ -17,10 +17,11 @@ falcon_receive_derive::falcon_receive! {
 impl PacketHandler<FalconConnection> for LoginStartPacket {
     fn handle_packet(self, connection: &mut FalconConnection) -> TaskScheduleResult {
         let version = connection.handler_state().protocol_id();
-        if FalconConfig::global().excluded_versions().contains(&version.unsigned_abs()) {
-            connection.disconnect(ChatComponent::from_text(
-                "Disabled version",
-                ComponentStyle::with_version(version.unsigned_abs()).color_if_absent(ChatColor::Red)
+
+         if FalconConfig::ALLOWED_VERSIONS.contains(&!47) == false {
+             connection.disconnect(ChatComponent::from_text(
+                 "Incompatible or Disabled version",
+                 ComponentStyle::with_version(version.unsigned_abs()).color_if_absent(ChatColor::Red)
             ));
         } else {
             let wrapper = connection.wrapper();


### PR DESCRIPTION
Fixes #7.
Desired behavior is for it to disconnect.

Branch got renamed following git flow semantics.

See #11 