### PR TITLE
♻️➖ Deal with fallable tasks in FalconServer & FalconConnection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,6 @@ dependencies = [
  "falcon_packet_core",
  "falcon_send",
  "flate2",
- "ignore-result",
  "itertools",
  "mc_chat",
  "thiserror",
@@ -296,7 +295,6 @@ dependencies = [
  "fastnbt",
  "flate2",
  "human-panic",
- "ignore-result",
  "mc_chat",
  "tokio",
  "tracing",
@@ -480,12 +478,6 @@ dependencies = [
  "toml",
  "uuid 0.8.2",
 ]
-
-[[package]]
-name = "ignore-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "665ff4dce8edd10d490641ccb78949832f1ddbff02c584fb1f85ab888fe0e50c"
 
 [[package]]
 name = "indexmap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ name = "falcon_logic"
 version = "0.2.0"
 dependencies = [
  "ahash",
+ "anyhow",
  "bytes",
  "falcon_core",
  "falcon_packet_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,7 @@ dependencies = [
 name = "falcon_receive"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "bytes",
  "falcon_core",
  "falcon_logic",
@@ -919,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.20.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes",
@@ -929,7 +930,6 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",

--- a/crates/logic/Cargo.toml
+++ b/crates/logic/Cargo.toml
@@ -18,6 +18,7 @@ flate2 = { version = "1.0.24", features = ["zlib-ng"], default-features = false 
 
 uuid = { version = "1.1.2", features = [ "v3" ] }
 bytes = "1.2.1"
+anyhow = "1.0.65"
 thiserror = "1.0.37"
 ahash = "0.8.0"
 

--- a/crates/logic/Cargo.toml
+++ b/crates/logic/Cargo.toml
@@ -18,7 +18,6 @@ flate2 = { version = "1.0.24", features = ["zlib-ng"], default-features = false 
 
 uuid = { version = "1.1.2", features = [ "v3" ] }
 bytes = "1.2.1"
-ignore-result = "0.2.0"
 thiserror = "1.0.37"
 ahash = "0.8.0"
 

--- a/crates/logic/src/connection/handler.rs
+++ b/crates/logic/src/connection/handler.rs
@@ -1,9 +1,14 @@
+use std::error::Error;
+
 use crate::FalconConnection;
 
 // This trait defines the packet logic when a packet gets received.
 pub trait PacketHandler {
+    /// The error that can occur when executing the packet logic
+    type Error: Error + Send + Sync + 'static;
+
     /// Executes packet logic.
-    fn handle_packet(self, connection: &mut FalconConnection);
+    fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Self::Error>;
 
     /// Human-readable identifier of the packet type
     fn get_name(&self) -> &'static str;

--- a/crates/logic/src/connection/mod.rs
+++ b/crates/logic/src/connection/mod.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 use std::pin::Pin;
 use std::time::Duration;
 
+use anyhow::Result;
 use bytes::Bytes;
 use falcon_core::network::{ConnectionState, PacketHandlerState, UNKNOWN_PROTOCOL};
 use falcon_core::ShutdownHandle;
@@ -23,8 +24,8 @@ mod tick;
 mod wrapper;
 pub mod writer;
 
-pub type SyncConnectionTask = dyn FnOnce(&mut FalconConnection) + Send + Sync;
-pub type AsyncConnectionTask = dyn (FnOnce(&mut FalconConnection) -> Pin<Box<dyn Future<Output = ()> + Send>>) + Send + Sync;
+pub type SyncConnectionTask = dyn FnOnce(&mut FalconConnection) -> Result<()> + Send + Sync ;
+pub type AsyncConnectionTask = dyn (FnOnce(&mut FalconConnection) -> Pin<Box<dyn Future<Output = Result<()>> + Send>>) + Send + Sync;
 
 pub enum ConnectionTask {
     Sync(Box<SyncConnectionTask>),

--- a/crates/logic/src/connection/mod.rs
+++ b/crates/logic/src/connection/mod.rs
@@ -24,7 +24,7 @@ mod tick;
 mod wrapper;
 pub mod writer;
 
-pub type SyncConnectionTask = dyn FnOnce(&mut FalconConnection) -> Result<()> + Send + Sync ;
+pub type SyncConnectionTask = dyn FnOnce(&mut FalconConnection) -> Result<()> + Send + Sync;
 pub type AsyncConnectionTask = dyn (FnOnce(&mut FalconConnection) -> Pin<Box<dyn Future<Output = Result<()>> + Send>>) + Send + Sync;
 
 pub enum ConnectionTask {

--- a/crates/logic/src/connection/mod.rs
+++ b/crates/logic/src/connection/mod.rs
@@ -7,7 +7,6 @@ use bytes::Bytes;
 use falcon_core::network::{ConnectionState, PacketHandlerState, UNKNOWN_PROTOCOL};
 use falcon_core::ShutdownHandle;
 use falcon_packet_core::{ReadError, WriteError};
-use ignore_result::Ignore;
 use mc_chat::ChatComponent;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver};
 use tokio::time::{interval, Interval, MissedTickBehavior};
@@ -108,9 +107,9 @@ impl FalconConnection {
     #[instrument(level = "trace", skip_all)]
     pub fn disconnect(&mut self, reason: ChatComponent) {
         match self.state.connection_state() {
-            ConnectionState::Play => self.send_packet(reason, falcon_send::write_play_disconnect).ignore(),
-            _ => self.send_packet(reason, falcon_send::write_login_disconnect).ignore(),
-        }
+            ConnectionState::Play => self.send_packet(reason, falcon_send::write_play_disconnect).ok(),
+            _ => self.send_packet(reason, falcon_send::write_login_disconnect).ok(),
+        };
         self.state.set_connection_state(ConnectionState::Disconnected);
         trace!("Player connection marked as disconnected");
     }

--- a/crates/logic/src/connection/tick.rs
+++ b/crates/logic/src/connection/tick.rs
@@ -40,14 +40,17 @@ impl FalconConnection {
                     };
                     let span = debug_span!("connection_task", state = %self.state);
                     let _enter = span.enter();
-                    match task {
+                    let res = match task {
                         ConnectionTask::Sync(task) => {
                             task(&mut self)
                         }
                         ConnectionTask::Async(task) => {
                             task(&mut self).await
                         }
-                    }
+                    };
+                    if let Err(error) = res {
+                        self.disconnect(ChatComponent::from_text(format!("Error on task: {}", error), ComponentStyle::with_version(self.state.protocol_id().unsigned_abs())));
+                    };
                 }
 
                 n = socket_readhalf.read_buf(&mut socket_read) => {

--- a/crates/logic/src/connection/tick.rs
+++ b/crates/logic/src/connection/tick.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use bytes::{Buf, Bytes};
 use falcon_core::error::FalconCoreError;
 use falcon_core::network::ConnectionState;
@@ -41,14 +42,10 @@ impl FalconConnection {
                     let span = debug_span!("connection_task", state = %self.state);
                     let _enter = span.enter();
                     if let Err(error) = match task {
-                        ConnectionTask::Sync(task) => {
-                            task(&mut self)
-                        }
-                        ConnectionTask::Async(task) => {
-                            task(&mut self).await
-                        }
+                        ConnectionTask::Sync(task) => task.run(&mut self),
+                        ConnectionTask::Async(task) => task.run(&mut self).await,
                     } {
-                        self.disconnect(ChatComponent::from_text(format!("Error on task: {}", error), ComponentStyle::with_version(self.state.protocol_id().unsigned_abs())));
+                        self.disconnect(ChatComponent::from_text(format!("Task errored: {}", error), ComponentStyle::with_version(self.state.protocol_id().unsigned_abs())));
                     };
                 }
 
@@ -91,7 +88,7 @@ impl FalconConnection {
     }
 }
 
-fn process_packet<R: ConnectionReceiver>(connection: &mut FalconConnection, mut packet: Bytes, receiver: &mut R) -> Result<(), ReceiveError> {
+fn process_packet<R: ConnectionReceiver>(connection: &mut FalconConnection, mut packet: Bytes, receiver: &mut R) -> Result<()> {
     let packet_id = VarI32::read(&mut packet)?.val();
     let span = trace_span!("packet", packet_id = %format!("{:#04X}", packet_id));
     let _enter = span.enter();
@@ -110,6 +107,6 @@ fn process_packet<R: ConnectionReceiver>(connection: &mut FalconConnection, mut 
 enum ReceiveError {
     #[error("Core error")]
     Core(#[from] FalconCoreError),
-    #[error("packet read error")]
+    #[error("PacketRead error")]
     Read(#[from] ReadError),
 }

--- a/crates/logic/src/connection/tick.rs
+++ b/crates/logic/src/connection/tick.rs
@@ -40,15 +40,14 @@ impl FalconConnection {
                     };
                     let span = debug_span!("connection_task", state = %self.state);
                     let _enter = span.enter();
-                    let res = match task {
+                    if let Err(error) = match task {
                         ConnectionTask::Sync(task) => {
                             task(&mut self)
                         }
                         ConnectionTask::Async(task) => {
                             task(&mut self).await
                         }
-                    };
-                    if let Err(error) = res {
+                    } {
                         self.disconnect(ChatComponent::from_text(format!("Error on task: {}", error), ComponentStyle::with_version(self.state.protocol_id().unsigned_abs())));
                     };
                 }

--- a/crates/logic/src/connection/wrapper.rs
+++ b/crates/logic/src/connection/wrapper.rs
@@ -1,7 +1,6 @@
 use std::fmt::Debug;
 
 use falcon_packet_core::WriteError;
-use ignore_result::Ignore;
 use tokio::sync::mpsc::UnboundedSender;
 use tracing::error;
 
@@ -22,7 +21,7 @@ impl ConnectionWrapper {
             .send(ConnectionTask::Sync(Box::new(|connection| {
                 connection.reset_keep_alive();
             })))
-            .ignore();
+            .ok();
     }
 
     pub fn send_packet<T, F>(&self, packet: T, write_fn: F)
@@ -36,7 +35,7 @@ impl ConnectionWrapper {
                     error!("Error when sending packet: {}", err);
                 }
             })))
-            .ignore()
+            .ok();
     }
 
     /// Do not pass a `Box` to this function.
@@ -44,7 +43,7 @@ impl ConnectionWrapper {
     where
         T: FnOnce(&mut FalconConnection) + Send + Sync + 'static,
     {
-        self.link.send(ConnectionTask::Sync(Box::new(task))).ignore();
+        self.link.send(ConnectionTask::Sync(Box::new(task))).ok();
     }
 }
 

--- a/crates/logic/src/connection/wrapper.rs
+++ b/crates/logic/src/connection/wrapper.rs
@@ -32,11 +32,7 @@ impl ConnectionWrapper {
         F: FnOnce(T, &mut SocketWrite, i32) -> Result<bool, WriteError> + Send + Sync + 'static,
     {
         self.link
-            .send(ConnectionTask::Sync(Box::new(move |connection| {
-                connection.send_packet(packet, write_fn)?;
-
-                Ok(())
-            })))
+            .send(ConnectionTask::Sync(Box::new(move |connection| Ok(connection.send_packet(packet, write_fn)?))))
             .ok();
     }
 

--- a/crates/logic/src/player/mod.rs
+++ b/crates/logic/src/player/mod.rs
@@ -80,6 +80,8 @@ impl FalconPlayer {
     pub fn disconnect(&mut self, reason: ChatComponent) {
         self.connection.execute_sync(move |connection| {
             connection.disconnect(reason);
+
+            Ok(())
         });
     }
 
@@ -88,8 +90,9 @@ impl FalconPlayer {
         let elapsed = self.time.elapsed().as_secs();
         self.connection.execute_sync(move |connection| {
             connection.handler_state_mut().set_last_keep_alive(elapsed);
-            // TODO: remove ignore
-            connection.send_packet(elapsed as i64, falcon_send::write_keep_alive).ok();
+            connection.send_packet(elapsed as i64, falcon_send::write_keep_alive)?;
+
+            Ok(())
         });
     }
 

--- a/crates/logic/src/player/mod.rs
+++ b/crates/logic/src/player/mod.rs
@@ -1,6 +1,9 @@
+use std::convert::Infallible;
+
 use falcon_core::player::data::{GameMode, LookAngles, PlayerAbilityFlags, Position};
 use falcon_core::server::config::FalconConfig;
 use falcon_core::server::data::Difficulty;
+use falcon_packet_core::WriteError;
 use falcon_send::specs::play::JoinGameSpec;
 use mc_chat::ChatComponent;
 use tokio::time::Instant;
@@ -77,15 +80,20 @@ impl FalconPlayer {
 }
 
 impl FalconPlayer {
-    pub fn disconnect(&mut self, reason: ChatComponent) { self.connection.execute_sync(move |connection| Ok(connection.disconnect(reason))); }
+    pub fn disconnect(&mut self, reason: ChatComponent) {
+        self.connection.execute(move |connection| {
+            connection.disconnect(reason);
+            Ok::<(), Infallible>(())
+        });
+    }
 
     #[tracing::instrument(skip(self))]
     pub fn send_keep_alive(&self) {
         let elapsed = self.time.elapsed().as_secs();
-        self.connection.execute_sync(move |connection| {
+        self.connection.execute(move |connection| -> Result<(), WriteError> {
             connection.handler_state_mut().set_last_keep_alive(elapsed);
-
-            Ok(connection.send_packet(elapsed as i64, falcon_send::write_keep_alive)?)
+            connection.send_packet(elapsed as i64, falcon_send::write_keep_alive)?;
+            Ok(())
         });
     }
 

--- a/crates/logic/src/player/mod.rs
+++ b/crates/logic/src/player/mod.rs
@@ -2,7 +2,6 @@ use falcon_core::player::data::{GameMode, LookAngles, PlayerAbilityFlags, Positi
 use falcon_core::server::config::FalconConfig;
 use falcon_core::server::data::Difficulty;
 use falcon_send::specs::play::JoinGameSpec;
-use ignore_result::Ignore;
 use mc_chat::ChatComponent;
 use tokio::time::Instant;
 use uuid::Uuid;
@@ -90,7 +89,7 @@ impl FalconPlayer {
         self.connection.execute_sync(move |connection| {
             connection.handler_state_mut().set_last_keep_alive(elapsed);
             // TODO: remove ignore
-            connection.send_packet(elapsed as i64, falcon_send::write_keep_alive).ignore();
+            connection.send_packet(elapsed as i64, falcon_send::write_keep_alive).ok();
         });
     }
 

--- a/crates/logic/src/player/mod.rs
+++ b/crates/logic/src/player/mod.rs
@@ -77,22 +77,15 @@ impl FalconPlayer {
 }
 
 impl FalconPlayer {
-    pub fn disconnect(&mut self, reason: ChatComponent) {
-        self.connection.execute_sync(move |connection| {
-            connection.disconnect(reason);
-
-            Ok(())
-        });
-    }
+    pub fn disconnect(&mut self, reason: ChatComponent) { self.connection.execute_sync(move |connection| Ok(connection.disconnect(reason))); }
 
     #[tracing::instrument(skip(self))]
     pub fn send_keep_alive(&self) {
         let elapsed = self.time.elapsed().as_secs();
         self.connection.execute_sync(move |connection| {
             connection.handler_state_mut().set_last_keep_alive(elapsed);
-            connection.send_packet(elapsed as i64, falcon_send::write_keep_alive)?;
 
-            Ok(())
+            Ok(connection.send_packet(elapsed as i64, falcon_send::write_keep_alive)?)
         });
     }
 

--- a/crates/logic/src/server/mod.rs
+++ b/crates/logic/src/server/mod.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 use std::pin::Pin;
 
+use anyhow::Result;
 use ahash::AHashMap;
 use falcon_core::ShutdownHandle;
 use tokio::sync::mpsc::UnboundedReceiver;
@@ -14,8 +15,8 @@ mod network;
 mod tick;
 mod wrapper;
 
-pub type SyncServerTask = dyn FnOnce(&mut FalconServer) + Send + Sync;
-pub type AsyncServerTask = dyn (FnOnce(&mut FalconServer) -> Pin<Box<dyn Future<Output = ()>>>) + Send + Sync;
+pub type SyncServerTask = dyn FnOnce(&mut FalconServer) -> Result<()>  + Send + Sync;
+pub type AsyncServerTask = dyn (FnOnce(&mut FalconServer) -> Pin<Box<dyn Future<Output = Result<()>>>>) + Send + Sync;
 
 pub enum ServerTask {
     Sync(Box<SyncServerTask>),

--- a/crates/logic/src/server/mod.rs
+++ b/crates/logic/src/server/mod.rs
@@ -1,8 +1,9 @@
+use std::error::Error;
 use std::future::Future;
 use std::pin::Pin;
 
-use anyhow::Result;
 use ahash::AHashMap;
+use anyhow::Result;
 use falcon_core::ShutdownHandle;
 use tokio::sync::mpsc::UnboundedReceiver;
 use uuid::Uuid;
@@ -15,12 +16,17 @@ mod network;
 mod tick;
 mod wrapper;
 
-pub type SyncServerTask = dyn FnOnce(&mut FalconServer) -> Result<()>  + Send + Sync;
-pub type AsyncServerTask = dyn (FnOnce(&mut FalconServer) -> Pin<Box<dyn Future<Output = Result<()>>>>) + Send + Sync;
+pub trait SyncServerTask: Send + Sync {
+    fn run(self: Box<Self>, server: &mut FalconServer) -> Result<()>;
+}
+
+pub trait SyncFutServerTask: Send + Sync {
+    fn run(self: Box<Self>, server: &mut FalconServer) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>>;
+}
 
 pub enum ServerTask {
-    Sync(Box<SyncServerTask>),
-    Async(Box<AsyncServerTask>),
+    Sync(Box<dyn SyncServerTask>),
+    Async(Box<dyn SyncFutServerTask>),
 }
 
 pub struct FalconServer {
@@ -55,4 +61,20 @@ impl FalconServer {
     pub fn player_mut(&mut self, uuid: Uuid) -> Option<&mut FalconPlayer> { self.players.get_mut(&uuid) }
 
     pub fn world(&mut self) -> &mut FalconWorld { &mut self.world }
+}
+
+impl<F, E> SyncServerTask for F
+where
+    E: Error + Send + Sync + 'static,
+    F: FnOnce(&mut FalconServer) -> Result<(), E> + Send + Sync,
+{
+    fn run(self: Box<Self>, server: &mut FalconServer) -> Result<()> { Ok(self(server)?) }
+}
+
+impl<F, E> SyncFutServerTask for F
+where
+    E: Error + Send + Sync + 'static,
+    F: FnOnce(&mut FalconServer) -> Pin<Box<dyn Future<Output = Result<(), E>> + Send>> + Send + Sync + 'static,
+{
+    fn run(self: Box<F>, server: &mut FalconServer) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> { Box::pin(async { Ok(self(server).await?) }) }
 }

--- a/crates/logic/src/server/network/login.rs
+++ b/crates/logic/src/server/network/login.rs
@@ -17,12 +17,10 @@ impl FalconServer {
         let player_uuid = Uuid::new_v3(&Uuid::NAMESPACE_DNS, username.as_bytes());
         let username2 = username.clone();
         connection.execute_sync(move |connection| {
-            connection
-                .send_packet(LoginSuccessSpec::new(player_uuid, username2), falcon_send::write_login_success)?;
+            connection.send_packet(LoginSuccessSpec::new(player_uuid, username2), falcon_send::write_login_success)?;
             let handler_state = connection.handler_state_mut();
             handler_state.set_connection_state(ConnectionState::Play);
             handler_state.set_player_uuid(player_uuid);
-
             Ok(())
         });
         self.login_success(username, player_uuid, protocol, connection);

--- a/crates/logic/src/server/network/login.rs
+++ b/crates/logic/src/server/network/login.rs
@@ -3,7 +3,6 @@ use falcon_core::server::config::FalconConfig;
 use falcon_core::server::data::Difficulty;
 use falcon_send::specs::login::LoginSuccessSpec;
 use falcon_send::specs::play::{PlayerAbilitiesSpec, PositionAndLookSpec, ServerDifficultySpec};
-use ignore_result::Ignore;
 use tracing::{debug, error, info};
 use uuid::Uuid;
 
@@ -21,7 +20,7 @@ impl FalconServer {
             // TODO: remove ignore
             connection
                 .send_packet(LoginSuccessSpec::new(player_uuid, username2), falcon_send::write_login_success)
-                .ignore();
+                .ok();
             let handler_state = connection.handler_state_mut();
             handler_state.set_connection_state(ConnectionState::Play);
             handler_state.set_player_uuid(player_uuid);

--- a/crates/logic/src/server/network/login.rs
+++ b/crates/logic/src/server/network/login.rs
@@ -1,6 +1,7 @@
 use falcon_core::network::ConnectionState;
 use falcon_core::server::config::FalconConfig;
 use falcon_core::server::data::Difficulty;
+use falcon_packet_core::WriteError;
 use falcon_send::specs::login::LoginSuccessSpec;
 use falcon_send::specs::play::{PlayerAbilitiesSpec, PositionAndLookSpec, ServerDifficultySpec};
 use tracing::{debug, error, info};
@@ -16,7 +17,7 @@ impl FalconServer {
         // TODO: create minecraft uuids
         let player_uuid = Uuid::new_v3(&Uuid::NAMESPACE_DNS, username.as_bytes());
         let username2 = username.clone();
-        connection.execute_sync(move |connection| {
+        connection.execute(move |connection| -> Result<(), WriteError> {
             connection.send_packet(LoginSuccessSpec::new(player_uuid, username2), falcon_send::write_login_success)?;
             let handler_state = connection.handler_state_mut();
             handler_state.set_connection_state(ConnectionState::Play);

--- a/crates/logic/src/server/network/login.rs
+++ b/crates/logic/src/server/network/login.rs
@@ -17,20 +17,20 @@ impl FalconServer {
         let player_uuid = Uuid::new_v3(&Uuid::NAMESPACE_DNS, username.as_bytes());
         let username2 = username.clone();
         connection.execute_sync(move |connection| {
-            // TODO: remove ignore
             connection
-                .send_packet(LoginSuccessSpec::new(player_uuid, username2), falcon_send::write_login_success)
-                .ok();
+                .send_packet(LoginSuccessSpec::new(player_uuid, username2), falcon_send::write_login_success)?;
             let handler_state = connection.handler_state_mut();
             handler_state.set_connection_state(ConnectionState::Play);
             handler_state.set_player_uuid(player_uuid);
+
+            Ok(())
         });
         self.login_success(username, player_uuid, protocol, connection);
     }
 
     pub fn login_success(&mut self, username: String, uuid: Uuid, protocol: i32, connection: ConnectionWrapper) {
         if self.players.contains_key(&uuid) {
-            // TODO: Kick duplicqted playeers
+            // TODO: Kick duplicated players
             error!(%uuid, %username, "Duplicate player joining");
         }
         info!(name = %username, "Player joined the game!");

--- a/crates/logic/src/server/tick.rs
+++ b/crates/logic/src/server/tick.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use tokio::runtime::Builder;
 use tokio::time::MissedTickBehavior;
-use tracing::{debug, debug_span, info};
+use tracing::{debug, debug_span, info, error};
 
 use super::ServerTask;
 use crate::FalconServer;
@@ -42,9 +42,11 @@ impl FalconServer {
         while let Ok(task) = self.receiver.try_recv() {
             let span = debug_span!("server_task");
             let _enter = span.enter();
-            match task {
+            if let Err(error) = match task {
                 ServerTask::Sync(task) => task(self),
                 ServerTask::Async(task) => task(self).await,
+            } {
+                error!("ERROR: {}", error);
             }
         }
         while let Ok(command) = self.console_rx.try_recv() {

--- a/crates/logic/src/server/tick.rs
+++ b/crates/logic/src/server/tick.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use tokio::runtime::Builder;
 use tokio::time::MissedTickBehavior;
-use tracing::{debug, debug_span, info, error};
+use tracing::{debug, debug_span, error, info};
 
 use super::ServerTask;
 use crate::FalconServer;
@@ -43,10 +43,10 @@ impl FalconServer {
             let span = debug_span!("server_task");
             let _enter = span.enter();
             if let Err(error) = match task {
-                ServerTask::Sync(task) => task(self),
-                ServerTask::Async(task) => task(self).await,
+                ServerTask::Sync(task) => task.run(self),
+                ServerTask::Async(task) => task.run(self).await,
             } {
-                error!("ERROR: {}", error);
+                error!(%error);
             }
         }
         while let Ok(command) = self.console_rx.try_recv() {

--- a/crates/logic/src/server/wrapper.rs
+++ b/crates/logic/src/server/wrapper.rs
@@ -1,5 +1,4 @@
 use falcon_core::player::data::Position;
-use ignore_result::Ignore;
 use tokio::sync::mpsc::UnboundedSender;
 use uuid::Uuid;
 
@@ -20,7 +19,7 @@ impl ServerWrapper {
     where
         T: FnOnce(&mut FalconServer) + Send + Sync + 'static,
     {
-        self.link.send(ServerTask::Sync(Box::new(task))).ignore();
+        self.link.send(ServerTask::Sync(Box::new(task))).ok();
     }
 }
 

--- a/crates/logic/src/server/wrapper.rs
+++ b/crates/logic/src/server/wrapper.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use falcon_core::player::data::Position;
 use tokio::sync::mpsc::UnboundedSender;
 use uuid::Uuid;
@@ -17,7 +18,7 @@ impl ServerWrapper {
     /// Do not pass a `Box` to this function.
     pub fn execute_sync<T>(&self, task: T)
     where
-        T: FnOnce(&mut FalconServer) + Send + Sync + 'static,
+        T: FnOnce(&mut FalconServer) -> Result<()> + Send + Sync + 'static,
     {
         self.link.send(ServerTask::Sync(Box::new(task))).ok();
     }
@@ -26,31 +27,31 @@ impl ServerWrapper {
 impl ServerWrapper {
     pub fn request_status(&self, protocol: i32, connection: ConnectionWrapper) {
         self.execute_sync(move |server| {
-            server.request_status(protocol, connection);
+            Ok(server.request_status(protocol, connection))
         })
     }
 
     pub fn player_login(&self, username: String, protocol: i32, connection: ConnectionWrapper) {
         self.execute_sync(move |server| {
-            server.player_login(username, protocol, connection);
+            Ok(server.player_login(username, protocol, connection))
         })
     }
 
     pub fn player_update_pos_look(&self, uuid: Uuid, pos: Option<Position>, facing: Option<(f32, f32)>, on_ground: bool) {
         self.execute_sync(move |server| {
-            server.player_update_pos_look(uuid, pos, facing, on_ground);
+            Ok(server.player_update_pos_look(uuid, pos, facing, on_ground))
         })
     }
 
     pub fn player_update_view_distance(&self, uuid: Uuid, view_distance: u8) {
         self.execute_sync(move |server| {
-            server.player_update_view_distance(uuid, view_distance);
+            Ok(server.player_update_view_distance(uuid, view_distance))
         })
     }
 
     pub fn player_leave(&self, uuid: Uuid) {
         self.execute_sync(move |server| {
-            server.player_leave(uuid);
+            Ok(server.player_leave(uuid))
         })
     }
 }

--- a/crates/logic/src/server/wrapper.rs
+++ b/crates/logic/src/server/wrapper.rs
@@ -1,9 +1,12 @@
+use std::convert::Infallible;
+use std::error::Error;
+
 use anyhow::Result;
 use falcon_core::player::data::Position;
 use tokio::sync::mpsc::UnboundedSender;
 use uuid::Uuid;
 
-use super::ServerTask;
+use super::{ServerTask, SyncServerTask};
 use crate::connection::ConnectionWrapper;
 use crate::FalconServer;
 
@@ -16,43 +19,60 @@ impl ServerWrapper {
     pub fn new(link: UnboundedSender<ServerTask>) -> Self { Self { link } }
 
     /// Do not pass a `Box` to this function.
-    pub fn execute_sync<T>(&self, task: T)
+    #[inline]
+    pub fn send<T>(&self, task: T)
     where
-        T: FnOnce(&mut FalconServer) -> Result<()> + Send + Sync + 'static,
+        T: SyncServerTask + 'static,
     {
+        // SAFE: if this channel returns an error, the server will have shut down
+        // already.
         self.link.send(ServerTask::Sync(Box::new(task))).ok();
+    }
+
+    /// Do not pass a `Box` to this function.
+    pub fn execute<F, E>(&self, task: F)
+    where
+        E: Error + Send + Sync + 'static,
+        F: FnOnce(&mut FalconServer) -> Result<(), E> + Send + Sync + 'static,
+    {
+        self.send(task);
     }
 }
 
 impl ServerWrapper {
     pub fn request_status(&self, protocol: i32, connection: ConnectionWrapper) {
-        self.execute_sync(move |server| {
-            Ok(server.request_status(protocol, connection))
-        })
+        self.execute(move |server| {
+            server.request_status(protocol, connection);
+            Ok::<(), Infallible>(())
+        });
     }
 
     pub fn player_login(&self, username: String, protocol: i32, connection: ConnectionWrapper) {
-        self.execute_sync(move |server| {
-            Ok(server.player_login(username, protocol, connection))
-        })
+        self.execute(move |server| {
+            server.player_login(username, protocol, connection);
+            Ok::<(), Infallible>(())
+        });
     }
 
     pub fn player_update_pos_look(&self, uuid: Uuid, pos: Option<Position>, facing: Option<(f32, f32)>, on_ground: bool) {
-        self.execute_sync(move |server| {
-            Ok(server.player_update_pos_look(uuid, pos, facing, on_ground))
-        })
+        self.execute(move |server| {
+            server.player_update_pos_look(uuid, pos, facing, on_ground);
+            Ok::<(), Infallible>(())
+        });
     }
 
     pub fn player_update_view_distance(&self, uuid: Uuid, view_distance: u8) {
-        self.execute_sync(move |server| {
-            Ok(server.player_update_view_distance(uuid, view_distance))
-        })
+        self.execute(move |server| {
+            server.player_update_view_distance(uuid, view_distance);
+            Ok::<(), Infallible>(())
+        });
     }
 
     pub fn player_leave(&self, uuid: Uuid) {
-        self.execute_sync(move |server| {
-            Ok(server.player_leave(uuid))
-        })
+        self.execute(move |server| {
+            server.player_leave(uuid);
+            Ok::<(), Infallible>(())
+        });
     }
 }
 

--- a/crates/main/Cargo.toml
+++ b/crates/main/Cargo.toml
@@ -24,7 +24,6 @@ tracing-subscriber = { version = "0.3.15", features = [ "local-time" ] }
 tracing-appender = "0.2.2"
 
 anyhow = "1.0.62"
-ignore-result = "0.2.0"
 human-panic = "1.0.3"
 
 flate2 = "1.0.24"

--- a/crates/main/src/network/mod.rs
+++ b/crates/main/src/network/mod.rs
@@ -5,7 +5,6 @@ use falcon_logic::connection::ConnectionReceiver;
 use falcon_logic::server::ServerWrapper;
 use falcon_logic::FalconConnection;
 use falcon_packet_core::ReadError;
-use ignore_result::Ignore;
 use tokio::net::TcpListener;
 use tracing::{debug, info};
 
@@ -51,7 +50,7 @@ impl NetworkListener {
                     match connection {
                         Ok((socket, addr)) => {
                             debug!(address = %addr, "Accepted connection");
-                            socket.set_nodelay(true).ignore();
+                            socket.set_nodelay(true).ok();
                             let connection = FalconConnection::new(
                                 self.shutdown_handle.clone(),
                                 addr,

--- a/crates/main/src/network/mod.rs
+++ b/crates/main/src/network/mod.rs
@@ -4,7 +4,6 @@ use falcon_core::ShutdownHandle;
 use falcon_logic::connection::ConnectionReceiver;
 use falcon_logic::server::ServerWrapper;
 use falcon_logic::FalconConnection;
-use falcon_packet_core::ReadError;
 use tokio::net::TcpListener;
 use tracing::{debug, info};
 
@@ -72,7 +71,7 @@ impl NetworkListener {
 struct FalconReceiver;
 
 impl ConnectionReceiver for FalconReceiver {
-    fn receive(&mut self, packet_id: i32, bytes: &mut bytes::Bytes, connection: &mut FalconConnection) -> Result<bool, ReadError> {
+    fn receive(&mut self, packet_id: i32, bytes: &mut bytes::Bytes, connection: &mut FalconConnection) -> anyhow::Result<bool> {
         falcon_receive::falcon_process_packet(packet_id, bytes, connection)
     }
 }

--- a/crates/main/src/server/console.rs
+++ b/crates/main/src/server/console.rs
@@ -2,7 +2,6 @@ use std::thread;
 
 use anyhow::{Context, Result};
 use falcon_core::ShutdownHandle;
-use ignore_result::Ignore;
 use tokio::sync::broadcast;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tracing::{info, trace};
@@ -36,7 +35,7 @@ impl ConsoleListener {
             let stdin = std::io::stdin();
             if let Err(ref e) = stdin.read_line(&mut buffer).with_context(|| "Could not read from stdin!") {
                 print_error!(e);
-                self.shutdown_handle.send(()).ignore();
+                self.shutdown_handle.send(()).ok();
                 break;
             } else {
                 trace!(input = %buffer, "Sending console input!");

--- a/crates/protocol_util/src/packet_versions.rs
+++ b/crates/protocol_util/src/packet_versions.rs
@@ -9,7 +9,6 @@ use syn::{Error, LitInt, Token};
 #[derive(Debug)]
 pub struct PacketVersionMappings {
     versions: Vec<(LitInt, Vec<(LitInt, bool)>)>,
-    /// TODO: change into Option<LitInt>
     is_exclude: Option<LitInt>,
 }
 

--- a/crates/receive/Cargo.toml
+++ b/crates/receive/Cargo.toml
@@ -18,3 +18,4 @@ bytes = "1.2.1"
 
 tracing = "0.1.36"
 thiserror = "1.0.32"
+anyhow = "1.0.65"

--- a/crates/receive/src/lib.rs
+++ b/crates/receive/src/lib.rs
@@ -1,7 +1,15 @@
+use thiserror::Error;
+
 mod macros;
 
 packet_modules! {
     extern pub mod v1_8_9;
     extern pub mod v1_12_2;
     extern pub mod v1_9;
+}
+
+#[derive(Error, Debug)]
+pub enum ReceiveError {
+    #[error("The player could not be found")]
+    PlayerNotFound,
 }

--- a/crates/receive/src/macros.rs
+++ b/crates/receive/src/macros.rs
@@ -25,7 +25,7 @@ macro_rules! packet_modules {
         $($($visi_login mod $mod_name_login;)*)?
         $($($visi_play mod $mod_name_play;)*)?
 
-        pub fn falcon_process_packet<B>(packet_id: i32, buffer: &mut B, connection: &mut ::falcon_logic::connection::FalconConnection) -> ::core::result::Result<bool, ::falcon_packet_core::ReadError>
+        pub fn falcon_process_packet<B>(packet_id: i32, buffer: &mut B, connection: &mut ::falcon_logic::connection::FalconConnection) -> ::anyhow::Result<bool>
         where
             B: ::bytes::Buf,
         {

--- a/crates/receive/src/v1_12_2/play.rs
+++ b/crates/receive/src/v1_12_2/play.rs
@@ -1,5 +1,7 @@
 #[falcon_receive_derive::falcon_receive]
 mod inner {
+    use std::convert::Infallible;
+
     use falcon_logic::{FalconConnection, connection::handler::PacketHandler};
     use falcon_packet_core::PacketRead;
     use mc_chat::{ChatComponent, ComponentStyle};
@@ -16,13 +18,16 @@ mod inner {
     }
 
     impl PacketHandler for KeepAlivePacket {
-        fn handle_packet(self, connection: &mut FalconConnection) {
+        type Error = Infallible;
+
+        fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Infallible> {
             if connection.handler_state().last_keep_alive() != self.id as u64 {
                 let version = connection.handler_state().protocol_id();
                 connection.disconnect(ChatComponent::from_text("Received invalid Keep Alive id!", ComponentStyle::with_version(version.unsigned_abs())));
             } else {
                 connection.reset_keep_alive();
             }
+            Ok(())
         }
 
         fn get_name(&self) -> &'static str {

--- a/crates/receive/src/v1_8_9/handshake.rs
+++ b/crates/receive/src/v1_8_9/handshake.rs
@@ -1,5 +1,7 @@
 #[falcon_receive_derive::falcon_receive]
 mod inner {
+    use std::convert::Infallible;
+
     use falcon_logic::{FalconConnection, connection::handler::PacketHandler};
     use falcon_packet_core::PacketRead;
     use mc_chat::{ChatComponent, ComponentStyle};
@@ -18,7 +20,9 @@ mod inner {
     }
 
     impl PacketHandler for HandshakePacket {
-        fn handle_packet(self, connection: &mut FalconConnection) {
+        type Error = Infallible;
+
+        fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Infallible> {
             match self.next_state {
                 1 => connection
                     .handler_state_mut()
@@ -33,6 +37,7 @@ mod inner {
             connection
                 .handler_state_mut()
                 .set_protocol_id(self.version);
+            Ok(())
         }
 
         fn get_name(&self) -> &'static str {

--- a/crates/receive/src/v1_8_9/login.rs
+++ b/crates/receive/src/v1_8_9/login.rs
@@ -1,5 +1,7 @@
 #[falcon_receive_derive::falcon_receive]
 mod inner {
+    use std::convert::Infallible;
+
     use falcon_packet_core::PacketRead;
     use mc_chat::{ChatColor, ChatComponent, ComponentStyle};
     use falcon_logic::connection::{FalconConnection, handler::PacketHandler};
@@ -15,7 +17,9 @@ mod inner {
     }
 
     impl PacketHandler for LoginStartPacket {
-        fn handle_packet(self, connection: &mut FalconConnection) {
+        type Error = Infallible;
+
+        fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Self::Error> {
             let version = connection.handler_state().protocol_id();
 
             if !FalconConfig::ALLOWED_VERSIONS.contains(&version.unsigned_abs()) {
@@ -31,9 +35,9 @@ mod inner {
                 ));
             } else {
                 let wrapper = connection.wrapper();
-                connection.server()
-                    .player_login(self.name, version, wrapper);
+                connection.server().player_login(self.name, version, wrapper);
             }
+            Ok(())
         }
 
         fn get_name(&self) -> &'static str {

--- a/crates/receive/src/v1_8_9/play.rs
+++ b/crates/receive/src/v1_8_9/play.rs
@@ -4,6 +4,8 @@ mod inner {
     use falcon_logic::{FalconConnection, connection::handler::PacketHandler};
     use falcon_packet_core::PacketRead;
 
+    use crate::ReceiveError;
+
     #[derive(PacketRead)]
     #[falcon_packet(versions = {
         47 = 0x04;
@@ -57,11 +59,12 @@ mod inner {
     }
 
     impl PacketHandler for PlayerPositionPacket {
-        fn handle_packet(self, connection: &mut FalconConnection) {
-            if let Some(uuid) = connection.handler_state().player_uuid() {
-                connection.server()
-                    .player_update_pos_look(uuid, Some(Position::new(self.x, self.y, self.z)), None, self.on_ground);
-            }
+        type Error = ReceiveError;
+
+        fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Self::Error> {
+            let uuid = connection.handler_state().player_uuid().ok_or(ReceiveError::PlayerNotFound)?;
+            connection.server().player_update_pos_look(uuid, Some(Position::new(self.x, self.y, self.z)), None, self.on_ground);
+            Ok(())
         }
 
         fn get_name(&self) -> &'static str {
@@ -70,10 +73,12 @@ mod inner {
     }
 
     impl PacketHandler for PlayerLookPacket {
-        fn handle_packet(self, connection: &mut FalconConnection) {
-            let uuid = connection.handler_state().player_uuid().expect("Something impossible happened");
-            connection.server()
-                .player_update_pos_look(uuid, None, Some((self.yaw, self.pitch)), self.on_ground);
+        type Error = ReceiveError;
+
+        fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Self::Error> {
+            let uuid = connection.handler_state().player_uuid().ok_or(ReceiveError::PlayerNotFound)?;
+            connection.server().player_update_pos_look(uuid, None, Some((self.yaw, self.pitch)), self.on_ground);
+            Ok(())
         }
 
         fn get_name(&self) -> &'static str {
@@ -82,10 +87,12 @@ mod inner {
     }
 
     impl PacketHandler for PositionLookPacket {
-        fn handle_packet(self, connection: &mut FalconConnection) {
-            let uuid = connection.handler_state().player_uuid().expect("Something impossible happened");
-            connection.server()
-                .player_update_pos_look(uuid, Some(Position::new(self.x, self.y, self.z)), Some((self.yaw, self.pitch)), self.on_ground);
+        type Error = ReceiveError;
+
+        fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Self::Error> {
+            let uuid = connection.handler_state().player_uuid().ok_or(ReceiveError::PlayerNotFound)?;
+            connection.server().player_update_pos_look(uuid, Some(Position::new(self.x, self.y, self.z)), Some((self.yaw, self.pitch)), self.on_ground);
+            Ok(())
         }
 
         fn get_name(&self) -> &'static str {

--- a/crates/receive_derive/src/lib.rs
+++ b/crates/receive_derive/src/lib.rs
@@ -61,7 +61,7 @@ pub(crate) fn generate(data: ReceiveMatchMappings) -> ItemFn {
                         let packet_name = ::falcon_logic::connection::handler::PacketHandler::get_name(&packet);
                         let span = ::tracing::trace_span!("handle_packet", %packet_name);
                         let _enter = span.enter();
-                        ::falcon_logic::connection::handler::PacketHandler::handle_packet(packet, connection);
+                        ::falcon_logic::connection::handler::PacketHandler::handle_packet(packet, connection)?;
                         Ok(true)
                     }
                 },
@@ -77,7 +77,7 @@ pub(crate) fn generate(data: ReceiveMatchMappings) -> ItemFn {
                                     let packet_name = ::falcon_logic::connection::handler::PacketHandler::get_name(&packet);
                                     let span = ::tracing::trace_span!("handle_packet", %packet_name);
                                     let _enter = span.enter();
-                                    ::falcon_logic::connection::handler::PacketHandler::handle_packet(packet, connection);
+                                    ::falcon_logic::connection::handler::PacketHandler::handle_packet(packet, connection)?;
                                     Ok(true)
                                 }
                             }
@@ -97,7 +97,7 @@ pub(crate) fn generate(data: ReceiveMatchMappings) -> ItemFn {
         .collect();
 
     parse_quote! {
-        pub fn falcon_process_packet<B>(packet_id: i32, buffer: &mut B, connection: &mut ::falcon_logic::connection::FalconConnection) -> ::core::result::Result<bool, ::falcon_packet_core::ReadError>
+        pub fn falcon_process_packet<B>(packet_id: i32, buffer: &mut B, connection: &mut ::falcon_logic::connection::FalconConnection) -> ::anyhow::Result<bool>
         where
             B: ::bytes::Buf,
         {

--- a/crates/send/src/v1_8_9/login.rs
+++ b/crates/send/src/v1_8_9/login.rs
@@ -17,7 +17,7 @@ mod inner {
     impl From<ChatComponent> for DisconnectPacket {
         fn from(reason: ChatComponent) -> Self {
             DisconnectPacket {
-                reason: serde_json::to_string(&reason).unwrap(),
+                reason: serde_json::to_string(&reason).expect("Invalid reason data"),
             }
         }
     }

--- a/crates/send/src/v1_8_9/play.rs
+++ b/crates/send/src/v1_8_9/play.rs
@@ -57,7 +57,7 @@ mod inner {
     impl From<ChatComponent> for DisconnectPacket {
         fn from(reason: ChatComponent) -> Self {
             DisconnectPacket {
-                reason: serde_json::to_string(&reason).unwrap(),
+                reason: serde_json::to_string(&reason).expect("Invalid reason data"),
             }
         }
     }


### PR DESCRIPTION
Using `.ok()` on results we do not care about achieves the same effect as using the ignore_result crate. One less dependency to bring down and worry about.

I also believe it reads the same as using ignore_result. `.ok()` as in "this is okay`.