### PR TITLE
🚚 Rename `handler_state` to `state` - Change getters/setters into pub fields

### DIFF
--- a/crates/core/src/network/mod.rs
+++ b/crates/core/src/network/mod.rs
@@ -10,10 +10,10 @@ pub const UNKNOWN_PROTOCOL: i32 = -1;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct PacketHandlerState {
-    uuid: Option<Uuid>,
-    last_keep_alive: u64,
-    protocol_id: i32,
-    connection_state: ConnectionState,
+    pub uuid: Option<Uuid>,
+    pub last_keep_alive: u64,
+    pub protocol_id: i32,
+    pub connection_state: ConnectionState,
 }
 
 impl Display for PacketHandlerState {
@@ -29,22 +29,6 @@ impl PacketHandlerState {
             connection_state: ConnectionState::Handshake,
         }
     }
-
-    pub fn player_uuid(&self) -> Option<Uuid> { self.uuid }
-
-    pub fn set_player_uuid(&mut self, uuid: Uuid) { self.uuid = Some(uuid); }
-
-    pub fn last_keep_alive(&self) -> u64 { self.last_keep_alive }
-
-    pub fn set_last_keep_alive(&mut self, last_keep_alive: u64) { self.last_keep_alive = last_keep_alive; }
-
-    pub fn protocol_id(&self) -> i32 { self.protocol_id }
-
-    pub fn set_protocol_id(&mut self, protocol_id: i32) { self.protocol_id = protocol_id; }
-
-    pub fn connection_state(&self) -> ConnectionState { self.connection_state }
-
-    pub fn set_connection_state(&mut self, state: ConnectionState) { self.connection_state = state; }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]

--- a/crates/core/src/player/data.rs
+++ b/crates/core/src/player/data.rs
@@ -14,10 +14,10 @@ impl From<GameMode> for u8 {
 
 #[derive(Clone, Copy, Default, Debug)]
 pub struct PlayerAbilityFlags {
-    invulnerable: bool,
-    flying: bool,
-    allow_flying: bool,
-    instant_break: bool,
+    pub invulnerable: bool,
+    pub flying: bool,
+    pub allow_flying: bool,
+    pub instant_break: bool,
 }
 
 impl PlayerAbilityFlags {
@@ -39,25 +39,13 @@ impl From<PlayerAbilityFlags> for u8 {
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
 pub struct Position {
-    x: f64,
-    y: f64,
-    z: f64,
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
 }
 
 impl Position {
     pub fn new(x: f64, y: f64, z: f64) -> Self { Position { x, y, z } }
-
-    pub fn x(&self) -> f64 { self.x }
-
-    pub fn y(&self) -> f64 { self.y }
-
-    pub fn z(&self) -> f64 { self.z }
-
-    pub fn set_x(&mut self, x: f64) { self.x = x; }
-
-    pub fn set_y(&mut self, y: f64) { self.y = y; }
-
-    pub fn set_z(&mut self, z: f64) { self.z = z; }
 
     /// A chunk is 16 wide to this function, this is hardcoded
     pub fn chunk_x(&self) -> i32 { (self.x as i32) >> 4 }
@@ -70,18 +58,10 @@ impl Position {
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize)]
 pub struct LookAngles {
-    yaw: f32,
-    pitch: f32,
+    pub yaw: f32,
+    pub pitch: f32,
 }
 
 impl LookAngles {
     pub fn new(yaw: f32, pitch: f32) -> Self { LookAngles { yaw, pitch } }
-
-    pub fn yaw(&self) -> f32 { self.yaw }
-
-    pub fn pitch(&self) -> f32 { self.pitch }
-
-    pub fn set_yaw(&mut self, yaw: f32) { self.yaw = yaw; }
-
-    pub fn set_pitch(&mut self, pitch: f32) { self.pitch = pitch; }
 }

--- a/crates/core/src/server/config.rs
+++ b/crates/core/src/server/config.rs
@@ -13,10 +13,10 @@ static INSTANCE: OnceCell<FalconConfig> = OnceCell::new();
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct FalconConfig {
-    connection: ConnectionSettings,
-    players: PlayerSettings,
-    server: ServerSettings,
-    versions: VersionSettings,
+    pub connection: ConnectionSettings,
+    pub players: PlayerSettings,
+    pub server: ServerSettings,
+    pub versions: VersionSettings,
 }
 
 impl FalconConfig {
@@ -30,35 +30,15 @@ impl FalconConfig {
         Ok(())
     }
 
-    pub fn server_port(&self) -> u16 { self.connection.server_port }
-
-    pub fn server_ip(&self) -> IpAddr { self.connection.server_ip }
-
-    pub fn server_socket_addrs(&self) -> impl ToSocketAddrs + '_ { (self.server_ip(), self.server_port()) }
-
-    pub fn max_players(&self) -> i32 { self.server.max_players }
-
-    pub fn description(&self) -> &str { &self.server.description }
+    pub fn server_socket_addrs(&self) -> impl ToSocketAddrs + '_ { (self.connection.server_ip, self.connection.server_port) }
 
     pub fn world_file(&self) -> Option<&str> { self.server.world.as_deref() }
-
-    pub fn tracing_level(&self) -> LevelFilter { self.server.tracing_level }
-
-    pub fn allow_flight(&self) -> bool { self.players.allow_flight }
-
-    pub fn max_view_distance(&self) -> u8 { self.players.max_view_distance }
-
-    pub fn spawn_pos(&self) -> Position { self.players.spawn_position }
-
-    pub fn spawn_look(&self) -> LookAngles { self.players.spawn_look }
-
-    pub fn excluded_versions(&self) -> &Vec<u32> { &self.versions.excluded }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConnectionSettings {
-    server_ip: IpAddr,
-    server_port: u16,
+    pub server_ip: IpAddr,
+    pub server_port: u16,
 }
 
 impl Default for ConnectionSettings {
@@ -72,10 +52,10 @@ impl Default for ConnectionSettings {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PlayerSettings {
-    allow_flight: bool,
-    max_view_distance: u8,
-    spawn_position: Position,
-    spawn_look: LookAngles,
+    pub allow_flight: bool,
+    pub max_view_distance: u8,
+    pub spawn_position: Position,
+    pub spawn_look: LookAngles,
 }
 
 impl Default for PlayerSettings {
@@ -92,11 +72,11 @@ impl Default for PlayerSettings {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ServerSettings {
     #[serde(with = "tracing_serde")]
-    tracing_level: LevelFilter,
-    max_players: i32,
-    description: String,
+    pub tracing_level: LevelFilter,
+    pub max_players: i32,
+    pub description: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    world: Option<String>,
+    pub world: Option<String>,
 }
 
 impl Default for ServerSettings {
@@ -112,7 +92,7 @@ impl Default for ServerSettings {
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct VersionSettings {
-    excluded: Vec<u32>,
+    pub excluded: Vec<u32>,
 }
 
 mod tracing_serde {

--- a/crates/core/src/server/data.rs
+++ b/crates/core/src/server/data.rs
@@ -24,7 +24,7 @@ pub struct ServerVersion {
 
 impl ServerVersion {
     pub fn new<T: Into<Cow<'static, str>>>(name: T, protocol_id: i32) -> Self {
-        let excluded = FalconConfig::global().excluded_versions();
+        let excluded = &FalconConfig::global().versions.excluded;
         let (name, version) = if !FalconConfig::ALLOWED_VERSIONS.contains(&protocol_id.unsigned_abs()) || excluded.contains(&protocol_id.unsigned_abs()) {
             let (name, mut protocol) = ("Unsupported version".into(), FalconConfig::ALLOWED_VERSIONS[0]);
             for version in FalconConfig::ALLOWED_VERSIONS {

--- a/crates/core/src/world/mod.rs
+++ b/crates/core/src/world/mod.rs
@@ -30,5 +30,5 @@ impl BlockPosition {
 }
 
 impl From<Position> for BlockPosition {
-    fn from(pos: Position) -> Self { BlockPosition::new(pos.x().floor() as i32, pos.y().floor() as i32, pos.z().floor() as i32) }
+    fn from(pos: Position) -> Self { BlockPosition::new(pos.x.floor() as i32, pos.y.floor() as i32, pos.z.floor() as i32) }
 }

--- a/crates/logic/src/player/mod.rs
+++ b/crates/logic/src/player/mod.rs
@@ -71,7 +71,7 @@ impl FalconPlayer {
     pub fn view_distance(&self) -> u8 { self.view_distance }
 
     pub fn set_view_distance(&mut self, distance: u8) {
-        self.view_distance = std::cmp::max(0, std::cmp::min(distance, FalconConfig::global().max_view_distance()));
+        self.view_distance = std::cmp::max(0, std::cmp::min(distance, FalconConfig::global().players.max_view_distance));
     }
 
     pub fn protocol_version(&self) -> i32 { self.protocol }
@@ -91,7 +91,7 @@ impl FalconPlayer {
     pub fn send_keep_alive(&self) {
         let elapsed = self.time.elapsed().as_secs();
         self.connection.execute(move |connection| -> Result<(), WriteError> {
-            connection.handler_state_mut().set_last_keep_alive(elapsed);
+            connection.state_mut().last_keep_alive = elapsed;
             connection.send_packet(elapsed as i64, falcon_send::write_keep_alive)?;
             Ok(())
         });

--- a/crates/logic/src/server/network/play.rs
+++ b/crates/logic/src/server/network/play.rs
@@ -19,18 +19,18 @@ impl FalconServer {
             Some(player) => {
                 let look_angles = player.look_angles_mut();
                 if let Some((yaw, pitch)) = facing {
-                    look_angles.set_yaw(yaw);
-                    look_angles.set_pitch(pitch);
+                    look_angles.yaw = yaw;
+                    look_angles.pitch = pitch;
                 }
                 let position = player.position_mut();
                 let (old_chunk_x, old_chunk_z) = position.chunk_coords();
                 if let Some(pos) = pos {
-                    position.set_x(pos.x());
-                    position.set_z(pos.z());
-                    if pos.y() as i32 != position.y() as i32 {
+                    position.x = pos.x;
+                    position.z = pos.z;
+                    if pos.y as i32 != position.y as i32 {
                         update_viewpos = true;
                     }
-                    position.set_y(pos.y());
+                    position.y = pos.y;
                 }
 
                 let (chunk_x, chunk_z) = (position.chunk_x(), position.chunk_z());

--- a/crates/logic/src/server/network/status.rs
+++ b/crates/logic/src/server/network/status.rs
@@ -8,8 +8,8 @@ use crate::server::FalconServer;
 impl FalconServer {
     pub fn request_status(&self, protocol: i32, connection: ConnectionWrapper) {
         let version = ServerVersion::new(String::from("1.13-1.17.1"), protocol);
-        let player_data = PlayerData::new(FalconConfig::global().max_players(), self.online_count() as i32);
-        let description = String::from(FalconConfig::global().description());
+        let player_data = PlayerData::new(FalconConfig::global().server.max_players, self.online_count() as i32);
+        let description = FalconConfig::global().server.description.clone();
         connection.send_packet(StatusResponseSpec::new(version, player_data, description), falcon_send::write_status_response);
     }
 }

--- a/crates/main/src/main.rs
+++ b/crates/main/src/main.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
              having launched (and shut down) FalconMC.",
         )?;
 
-        let filter_level = FalconConfig::global().tracing_level();
+        let filter_level = FalconConfig::global().server.tracing_level;
         handle_file.modify(|l| {
             *l.filter_mut() = filter_level;
         })?;

--- a/crates/receive/src/macros.rs
+++ b/crates/receive/src/macros.rs
@@ -32,7 +32,7 @@ macro_rules! packet_modules {
             $(if $mod_name_rest::falcon_process_packet(packet_id, buffer, connection)? {
                 return Ok(true);
             })*
-            let connection_state = connection.handler_state().connection_state();
+            let connection_state = connection.state().connection_state;
             match connection_state {
                 $(::falcon_core::network::ConnectionState::Handshake => {
                     $(if $mod_name_handshake::falcon_process_packet(packet_id, buffer, connection)? {

--- a/crates/receive/src/v1_12_2/play.rs
+++ b/crates/receive/src/v1_12_2/play.rs
@@ -21,8 +21,8 @@ mod inner {
         type Error = Infallible;
 
         fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Infallible> {
-            if connection.handler_state().last_keep_alive() != self.id as u64 {
-                let version = connection.handler_state().protocol_id();
+            if connection.state().last_keep_alive != self.id as u64 {
+                let version = connection.state().protocol_id;
                 connection.disconnect(ChatComponent::from_text("Received invalid Keep Alive id!", ComponentStyle::with_version(version.unsigned_abs())));
             } else {
                 connection.reset_keep_alive();

--- a/crates/receive/src/v1_8_9/handshake.rs
+++ b/crates/receive/src/v1_8_9/handshake.rs
@@ -24,19 +24,13 @@ mod inner {
 
         fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Infallible> {
             match self.next_state {
-                1 => connection
-                    .handler_state_mut()
-                    .set_connection_state(ConnectionState::Status),
-                2 => connection
-                    .handler_state_mut()
-                    .set_connection_state(ConnectionState::Login),
+                1 => connection.state_mut().connection_state = ConnectionState::Status,
+                2 => connection.state_mut().connection_state = ConnectionState::Login,
                 _ => {
                     connection.disconnect(ChatComponent::from_text("Impossible next state!", ComponentStyle::with_version(self.version.unsigned_abs())));
                 }
             }
-            connection
-                .handler_state_mut()
-                .set_protocol_id(self.version);
+            connection.state_mut().protocol_id = self.version;
             Ok(())
         }
 

--- a/crates/receive/src/v1_8_9/login.rs
+++ b/crates/receive/src/v1_8_9/login.rs
@@ -20,7 +20,7 @@ mod inner {
         type Error = Infallible;
 
         fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Self::Error> {
-            let version = connection.handler_state().protocol_id();
+            let version = connection.state().protocol_id;
 
             if !FalconConfig::ALLOWED_VERSIONS.contains(&version.unsigned_abs()) {
                  connection.disconnect(ChatComponent::from_text(
@@ -28,7 +28,7 @@ mod inner {
                      ComponentStyle::with_version(version.unsigned_abs()).color_if_absent(ChatColor::Red)
                 ));
             } 
-            if FalconConfig::global().excluded_versions().contains(&version.unsigned_abs()) {
+            if FalconConfig::global().versions.excluded.contains(&version.unsigned_abs()) {
                 connection.disconnect(ChatComponent::from_text(
                     "Disabled version",
                     ComponentStyle::with_version(version.unsigned_abs()).color_if_absent(ChatColor::Red)

--- a/crates/receive/src/v1_8_9/play.rs
+++ b/crates/receive/src/v1_8_9/play.rs
@@ -62,7 +62,7 @@ mod inner {
         type Error = ReceiveError;
 
         fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Self::Error> {
-            let uuid = connection.handler_state().player_uuid().ok_or(ReceiveError::PlayerNotFound)?;
+            let uuid = connection.state().uuid.ok_or(ReceiveError::PlayerNotFound)?;
             connection.server().player_update_pos_look(uuid, Some(Position::new(self.x, self.y, self.z)), None, self.on_ground);
             Ok(())
         }
@@ -76,7 +76,7 @@ mod inner {
         type Error = ReceiveError;
 
         fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Self::Error> {
-            let uuid = connection.handler_state().player_uuid().ok_or(ReceiveError::PlayerNotFound)?;
+            let uuid = connection.state().uuid.ok_or(ReceiveError::PlayerNotFound)?;
             connection.server().player_update_pos_look(uuid, None, Some((self.yaw, self.pitch)), self.on_ground);
             Ok(())
         }
@@ -90,7 +90,7 @@ mod inner {
         type Error = ReceiveError;
 
         fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Self::Error> {
-            let uuid = connection.handler_state().player_uuid().ok_or(ReceiveError::PlayerNotFound)?;
+            let uuid = connection.state().uuid.ok_or(ReceiveError::PlayerNotFound)?;
             connection.server().player_update_pos_look(uuid, Some(Position::new(self.x, self.y, self.z)), Some((self.yaw, self.pitch)), self.on_ground);
             Ok(())
         }

--- a/crates/receive/src/v1_8_9/status.rs
+++ b/crates/receive/src/v1_8_9/status.rs
@@ -22,7 +22,7 @@ mod inner {
 
         fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Infallible> {
             trace!("Status requested");
-            let version = connection.handler_state().protocol_id();
+            let version = connection.state().protocol_id;
             let wrapper = connection.wrapper();
             connection.server().request_status(version, wrapper);
             Ok(())
@@ -39,7 +39,7 @@ mod inner {
         fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Self::Error> {
             trace!("Sent status pong");
             connection.send_packet(self.payload, falcon_send::write_status_pong)?;
-            connection.handler_state_mut().set_connection_state(ConnectionState::Disconnected);
+            connection.state_mut().connection_state = ConnectionState::Disconnected;
             Ok(())
         }
 

--- a/crates/receive/src/v1_9/play.rs
+++ b/crates/receive/src/v1_9/play.rs
@@ -26,7 +26,7 @@ mod inner {
         type Error = ReceiveError;
 
         fn handle_packet(self, connection: &mut FalconConnection) -> Result<(), Self::Error> {
-            let uuid = connection.handler_state().player_uuid().ok_or(ReceiveError::PlayerNotFound)?;
+            let uuid = connection.state().uuid.ok_or(ReceiveError::PlayerNotFound)?;
             connection.server().player_update_view_distance(uuid, self.view_distance);
             Ok(())
         }

--- a/crates/receive_derive/src/lib.rs
+++ b/crates/receive_derive/src/lib.rs
@@ -101,7 +101,7 @@ pub(crate) fn generate(data: ReceiveMatchMappings) -> ItemFn {
         where
             B: ::bytes::Buf,
         {
-            let protocol_id = connection.handler_state().protocol_id();
+            let protocol_id = connection.state().protocol_id;
             match packet_id {
                 #(#match_arms)*
                 _ => Ok(false)

--- a/crates/send/src/specs/play.rs
+++ b/crates/send/src/specs/play.rs
@@ -33,11 +33,11 @@ define_spec! {
     PositionAndLookSpec => pos: &Position, look: &LookAngles {
         flags: u8,
         teleport_id: i32;
-        let x: f64 = pos.x(),
-        let y: f64 = pos.y(),
-        let z: f64 = pos.z(),
-        let yaw: f32 = look.yaw(),
-        let pitch: f32 = look.pitch()
+        let x: f64 = pos.x,
+        let y: f64 = pos.y,
+        let z: f64 = pos.z,
+        let yaw: f32 = look.yaw,
+        let pitch: f32 = look.pitch
     }
 }
 


### PR DESCRIPTION
Getters and setters sometimes just clutter code ([see here](https://users.rust-lang.org/t/public-getter-method-vs-pub-field/20147/4)). This pr slims that down a bit by making some fields public.

I've found `handler_state` and `handler_state_mut` always a bit too long, so I took the opportunity to rename this at the same time to `state` and `state_mut`.

As usual, lemme know your thoughts