### PR TITLE
Refactor commands & partially implement player kicking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ dependencies = [
  "flate2",
  "itertools",
  "mc_chat",
+ "shlex",
  "thiserror",
  "tokio",
  "tracing",
@@ -821,6 +822,12 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"

--- a/crates/logic/Cargo.toml
+++ b/crates/logic/Cargo.toml
@@ -21,5 +21,6 @@ bytes = "1.2.1"
 anyhow = "1.0.65"
 thiserror = "1.0.37"
 ahash = "0.8.0"
+shlex = "1.1.0"
 
 tokio = { version = "1.20.1", features = [ "net", "time", "tracing", "io-util" ]}

--- a/crates/logic/src/player/mod.rs
+++ b/crates/logic/src/player/mod.rs
@@ -5,7 +5,7 @@ use falcon_core::server::config::FalconConfig;
 use falcon_core::server::data::Difficulty;
 use falcon_packet_core::WriteError;
 use falcon_send::specs::play::JoinGameSpec;
-use mc_chat::ChatComponent;
+use mc_chat::{ChatComponent, ComponentStyle};
 use tokio::time::Instant;
 use uuid::Uuid;
 
@@ -110,5 +110,14 @@ impl FalconPlayer {
             reduced_debug,
             enable_respawn,
         )
+    }
+
+    fn kick(&mut self, reason: Option<&str>) {
+        let style = ComponentStyle::with_version(self.protocol.unsigned_abs());
+        let msg = match reason {
+            Some(r) => ChatComponent::from_text(format!("You've been kicked because: {}", r), style),
+            None => ChatComponent::from_text("You've been kicked!", style),
+        };
+        self.disconnect(msg);
     }
 }

--- a/crates/logic/src/server/command.rs
+++ b/crates/logic/src/server/command.rs
@@ -1,0 +1,87 @@
+use std::collections::VecDeque;
+use std::str::FromStr;
+
+use thiserror::Error;
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum Command {
+    Stop,
+    Kick(String),
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum CommandParseError {
+    #[error("Input was empty")]
+    EmptyInput,
+    #[error("Erroneous backslash or ended inside open quotation")]
+    ErroneousInput,
+    #[error("Unknown command {0}")]
+    InvalidCommand(String),
+    /// Contains syntax explanation string
+    #[error("Not enough arguments. {0}")]
+    NotEnoughArgs(&'static str),
+}
+
+impl FromStr for Command {
+    type Err = CommandParseError;
+
+    /// Parse command and it's arguments. Does not care about extra arguments
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // TODO: `vec.into::<VecDeque<_>>` is not preferable
+        // Use `shlex::Shlex::new` to get an iterator to collect into `VecDeque` rather
+        // than using the `Vec` intermediary Problem is you need check
+        // `Shlex.had_error` AFTER it's done iterating, so you can't use `collect` as
+        // that consumes shlex
+        let mut split: VecDeque<_> = match shlex::split(s.trim()) {
+            Some(val) => val.into(),
+            None => return Err(CommandParseError::ErroneousInput),
+        };
+
+        let command = match split.pop_front() {
+            Some(val) => val,
+            None => return Err(CommandParseError::EmptyInput),
+        }
+        .to_lowercase();
+        match command.as_str() {
+            "stop" => Ok(Self::Stop),
+            "kick" => match split.pop_front().map(Command::Kick) {
+                Some(val) => Ok(val),
+                None => Err(CommandParseError::NotEnoughArgs("kick <username>")),
+            },
+            _ => Err(CommandParseError::InvalidCommand(command)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kick() {
+        let input = r#"kick "cool PLAYER""#;
+        let res = Command::from_str(input).unwrap();
+        assert_eq!(Command::Kick(String::from("cool PLAYER")), res);
+    }
+
+    #[test]
+    fn stop() {
+        let input = "stop";
+        let res = Command::from_str(input).unwrap();
+        assert_eq!(Command::Stop, res);
+    }
+
+    #[test]
+    fn erroneous_input() {
+        let input = r#"42"\"#;
+        let res = Command::from_str(input);
+        assert_eq!(Err(CommandParseError::ErroneousInput), res);
+    }
+
+    #[test]
+    fn invalid_command() {
+        let input = "";
+        let res = Command::from_str(input);
+        assert_eq!(Err(CommandParseError::EmptyInput), res);
+    }
+}

--- a/crates/logic/src/server/mod.rs
+++ b/crates/logic/src/server/mod.rs
@@ -12,6 +12,7 @@ pub use wrapper::ServerWrapper;
 use crate::player::FalconPlayer;
 use crate::world::FalconWorld;
 
+mod command;
 mod network;
 mod tick;
 mod wrapper;

--- a/crates/logic/src/server/network/login.rs
+++ b/crates/logic/src/server/network/login.rs
@@ -38,6 +38,7 @@ impl FalconServer {
         self.eid_count += 1;
 
         self.players.insert(uuid, player);
+
         if let Some(player) = self.players.get(&uuid) {
             let join_game_spec =
                 player.join_spec(Difficulty::Peaceful, FalconConfig::global().max_players() as u8, String::from("customized"), 0, false, false);


### PR DESCRIPTION
This PR's scope got way out of hand. Originally it was just for implementing kicking on duplicate users, and so I needed to implement kicking, and so I thought I might as well implement a kick command, _and so_ I ended up refactoring commands all together. Sorry if this is a problem!

The current issue with finishing the kicking is that I am unable to get a `FalconPlayer` via the player's username. And so this PR blocks on that.