### PR TITLE
Find FalconPlayer by username

### DIFF
--- a/crates/logic/src/server/mod.rs
+++ b/crates/logic/src/server/mod.rs
@@ -36,6 +36,7 @@ pub struct FalconServer {
     receiver: UnboundedReceiver<ServerTask>,
     eid_count: i32,
     players: AHashMap<Uuid, FalconPlayer>,
+    usernames: AHashMap<String, Uuid>,
     world: FalconWorld,
 }
 
@@ -48,6 +49,7 @@ impl FalconServer {
             receiver,
             eid_count: 0,
             players: AHashMap::new(),
+            usernames: AHashMap::new(),
             world,
         }
     }
@@ -59,6 +61,10 @@ impl FalconServer {
     pub fn player(&self, uuid: Uuid) -> Option<&FalconPlayer> { self.players.get(&uuid) }
 
     pub fn player_mut(&mut self, uuid: Uuid) -> Option<&mut FalconPlayer> { self.players.get_mut(&uuid) }
+
+    pub fn player_by_username(&mut self, username: &String) -> Option<&FalconPlayer> { self.usernames.get(username).and_then(|x| self.players.get(x)) }
+
+    pub fn player_by_username_mut(&mut self, username: &String) -> Option<&mut FalconPlayer> { self.usernames.get(username).and_then(|x| self.players.get_mut(x)) }
 
     pub fn world(&mut self) -> &mut FalconWorld { &mut self.world }
 }

--- a/crates/logic/src/server/mod.rs
+++ b/crates/logic/src/server/mod.rs
@@ -62,9 +62,9 @@ impl FalconServer {
 
     pub fn player_mut(&mut self, uuid: Uuid) -> Option<&mut FalconPlayer> { self.players.get_mut(&uuid) }
 
-    pub fn player_by_username(&mut self, username: &String) -> Option<&FalconPlayer> { self.usernames.get(username).and_then(|x| self.players.get(x)) }
+    pub fn username(&mut self, username: &String) -> Option<&FalconPlayer> { self.usernames.get(username).and_then(|x| self.players.get(x)) }
 
-    pub fn player_by_username_mut(&mut self, username: &String) -> Option<&mut FalconPlayer> {
+    pub fn username_mut(&mut self, username: &String) -> Option<&mut FalconPlayer> {
         self.usernames.get(username).and_then(|x| self.players.get_mut(x))
     }
 

--- a/crates/logic/src/server/mod.rs
+++ b/crates/logic/src/server/mod.rs
@@ -64,7 +64,9 @@ impl FalconServer {
 
     pub fn player_by_username(&mut self, username: &String) -> Option<&FalconPlayer> { self.usernames.get(username).and_then(|x| self.players.get(x)) }
 
-    pub fn player_by_username_mut(&mut self, username: &String) -> Option<&mut FalconPlayer> { self.usernames.get(username).and_then(|x| self.players.get_mut(x)) }
+    pub fn player_by_username_mut(&mut self, username: &String) -> Option<&mut FalconPlayer> {
+        self.usernames.get(username).and_then(|x| self.players.get_mut(x))
+    }
 
     pub fn world(&mut self) -> &mut FalconWorld { &mut self.world }
 }

--- a/crates/logic/src/server/mod.rs
+++ b/crates/logic/src/server/mod.rs
@@ -64,9 +64,7 @@ impl FalconServer {
 
     pub fn username(&mut self, username: &String) -> Option<&FalconPlayer> { self.usernames.get(username).and_then(|x| self.players.get(x)) }
 
-    pub fn username_mut(&mut self, username: &String) -> Option<&mut FalconPlayer> {
-        self.usernames.get(username).and_then(|x| self.players.get_mut(x))
-    }
+    pub fn username_mut(&mut self, username: &String) -> Option<&mut FalconPlayer> { self.usernames.get(username).and_then(|x| self.players.get_mut(x)) }
 
     pub fn world(&mut self) -> &mut FalconWorld { &mut self.world }
 }

--- a/crates/logic/src/server/network/login.rs
+++ b/crates/logic/src/server/network/login.rs
@@ -34,10 +34,11 @@ impl FalconServer {
         }
         info!(name = %username, "Player joined the game!");
         let (spawn_pos, spawn_look) = (FalconConfig::global().spawn_pos(), FalconConfig::global().spawn_look());
-        let player = FalconPlayer::new(username, uuid, self.eid_count, spawn_pos, spawn_look, protocol, connection);
+        let player = FalconPlayer::new(username.clone(), uuid, self.eid_count, spawn_pos, spawn_look, protocol, connection);
         self.eid_count += 1;
 
         self.players.insert(uuid, player);
+        self.usernames.insert(username, uuid);
         if let Some(player) = self.players.get(&uuid) {
             let join_game_spec =
                 player.join_spec(Difficulty::Peaceful, FalconConfig::global().max_players() as u8, String::from("customized"), 0, false, false);

--- a/crates/logic/src/server/network/play.rs
+++ b/crates/logic/src/server/network/play.rs
@@ -5,14 +5,10 @@ use uuid::Uuid;
 use crate::server::FalconServer;
 
 impl FalconServer {
-    pub fn player_leave(&mut self, username: String) {
-        let uuid = match self.usernames.remove(&username) {
-            Some(val) => val,
-            None => return,
-        };
-        let player = self.players.remove(&uuid);
-        if let Some(player) = player {
-            info!(%uuid, name = player.username(), "Player disconnected!");
+    pub fn player_leave(&mut self, uuid: Uuid) {
+        if let Some(player) = self.players.remove(&uuid) {
+            self.usernames.remove(player.username());
+            info!(%uuid, username = player.username(), "Player disconnected!");
         }
     }
 

--- a/crates/logic/src/server/network/play.rs
+++ b/crates/logic/src/server/network/play.rs
@@ -5,7 +5,11 @@ use uuid::Uuid;
 use crate::server::FalconServer;
 
 impl FalconServer {
-    pub fn player_leave(&mut self, uuid: Uuid) {
+    pub fn player_leave(&mut self, username: String) {
+        let uuid = match self.usernames.remove(&username) {
+            Some(val) => val,
+            None => return,
+        };
         let player = self.players.remove(&uuid);
         if let Some(player) = player {
             info!(%uuid, name = player.username(), "Player disconnected!");

--- a/crates/logic/src/server/wrapper.rs
+++ b/crates/logic/src/server/wrapper.rs
@@ -70,7 +70,11 @@ impl ServerWrapper {
 
     pub fn player_leave(&self, uuid: Uuid) {
         self.execute(move |server| {
-            server.player_leave(uuid);
+            let player = match server.player(uuid) {
+                Some(val) => val,
+                None => return Ok(()),
+            };
+            server.player_leave(player.username().to_string());
             Ok::<(), Infallible>(())
         });
     }

--- a/crates/logic/src/server/wrapper.rs
+++ b/crates/logic/src/server/wrapper.rs
@@ -70,11 +70,7 @@ impl ServerWrapper {
 
     pub fn player_leave(&self, uuid: Uuid) {
         self.execute(move |server| {
-            let player = match server.player(uuid) {
-                Some(val) => val,
-                None => return Ok(()),
-            };
-            server.player_leave(player.username().to_string());
+            server.player_leave(uuid);
             Ok::<(), Infallible>(())
         });
     }


### PR DESCRIPTION
This adds the ability to find a `FalconPlayer` by their username instead of only their UUID. This works by holding one new hashmap `username => uuid` that we can then use to get the `FalconPlayer` from the players hashmap `uuid => FalconPlayer`.

This unblocks kicking player on duplicate player.