### PR TITLE
Avoid duplicate checks on pull requests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,9 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
 
 name: Continuous integration
 


### PR DESCRIPTION
Currently github actions is configured so that it runs checks on both push and pull_request, meaning commits on a pull request get checked twice. This results in a lot of clutter.